### PR TITLE
expose Redis lib 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod stats;
 pub use crate::redis::{
     with_custom_namespace, RedisConnection, RedisConnectionManager, RedisError, RedisPool,
 };
+pub use ::redis as redis_rs;
 pub use middleware::{ChainIter, ServerMiddleware};
 pub use processor::{Processor, WorkFetcher};
 pub use scheduled::Scheduled;


### PR DESCRIPTION
To use Redis with the 'cmd' command and leverage the Sidekiq connection pool, I expose the Redis library to ensure compatibility with the same library version and execute custom commands.

Usage example:
```rs
    if let Some(pool) = &app_context.redis {
        let mut conn = pool.get().await.unwrap();
        sidekiq::redis_rs::cmd("FLUSHDB")
            .query_async::<_, ()>(conn.unnamespaced_borrow_mut())
            .await
            .unwrap();
    }
```